### PR TITLE
feat(logging): add toggle for feature selection events (#83)

### DIFF
--- a/track_changes/code/default_logger_widget.py
+++ b/track_changes/code/default_logger_widget.py
@@ -182,6 +182,11 @@ class FeatureLogger(QDockWidget, Ui_SetupTrackingChanges):
         self.logger.info(f"11 | {self.author} stopped editing of layer \"{self.layer.id()}\"")
 
     def log_selection_changed(self):
+        # Check wheter logging features are selected
+        if not self.ui.cbTrackSelection.isChecked():
+            return
+        
+        # Track logging code 20
         for feature in self.layer.selectedFeatures():
             fid = feature.id()
             feature = self.layer.getFeature(fid)

--- a/track_changes/code/gpkg_logger_widget.py
+++ b/track_changes/code/gpkg_logger_widget.py
@@ -439,6 +439,11 @@ class FeatureLogger(QDockWidget, Ui_SetupTrackingChanges):
         self.logging_data(11, None, "stop editing", None)
 
     def log_selection_changed(self):
+        # Check wheter logging features are selected
+        if not self.ui.cbTrackSelection.isChecked():
+            return
+        
+        
         for feature in self.active_layer.selectedFeatures():
             fid = feature.id()
             feature = self.active_layer.getFeature(fid)

--- a/track_changes/ui/default_logger.ui
+++ b/track_changes/ui/default_logger.ui
@@ -79,6 +79,17 @@
         </item>
        </layout>
       </item>
+      <!-- Add the new checkbox for Feature Selection events -->
+      <item>
+       <widget class="QCheckBox" name="cbTrackSelection">
+        <property name="text">
+         <string>Log feature selection events</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>

--- a/track_changes/ui/gpkg_logger.ui
+++ b/track_changes/ui/gpkg_logger.ui
@@ -65,6 +65,17 @@
         </item>
        </layout>
       </item>
+      <!-- Insert the new checkbox here -->
+      <item>
+       <widget class="QCheckBox" name="cbTrackSelection">
+        <property name="text">
+         <string>Log feature selection events</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>


### PR DESCRIPTION
**Summary:**
This commit adds a new checkbox (**"Log feature selection events"**) to both the Default and GeoPackage tracking UIs, and updates the logging code to conditionally log feature selection events (`code 20`) only when the user enables this option.

**Changes:**
- Updated default_logger.ui and gpkg_logger.ui to include a new QCheckBox widget in the layout:
```
  <item>
    <widget class="QCheckBox" name="cbTrackSelection">
      <property name="text">
        <string>Log feature selection events</string>
      </property>
      <property name="checked">
        <bool>false</bool>
      </property>
    </widget>
  </item>
```
  This checkbox is inserted in the layout (after the Activate/Deactivate buttons) so that users can toggle logging for feature selection events.
  
- Modified the log_selection_changed() methods in default_logger_widget.py and gpkg_logger_widget.py by adding a conditional check at the very start:
```  
  if not self.ui.cbTrackSelection.isChecked():
      return
```
  This code ensures that if the checkbox **is not** checked (the default state), the function exits without logging selection events.
  
- Recompiled UI files and verified that with the checkbox unchecked, selection logging is disabled, and when checked, selection logging events are recorded.

This enhancement allows the plugin to reduce excessive logging while still giving users the option to enable feature selection logging if desired.

![Checkbox feature selection](https://github.com/user-attachments/assets/ffcffb9b-83aa-450b-97a6-92ca525ffd4b)

